### PR TITLE
Added support for reading deployment definitions from multi-document …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ install:
   - pip install .[test]
 
 script: pytest --cov twyla.kubedeploy --cov-report term-missing
+after_script:
+  - pip install codecov
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/TwylaHelps/twyla.kubedeploy.svg?branch=master)](https://travis-ci.org/TwylaHelps/twyla.kubedeploy)
+[![codecov](https://codecov.io/gh/TwylaHelps/twyla.kubedeploy/branch/master/graph/badge.svg)](https://codecov.io/gh/TwylaHelps/twyla.kubedeploy)
 
 # twyla.kubedeploy
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ result will be sent to the Kubernetes API. The result is the same as calling
 - [ ] improve test coverage
 - [ ] rethink interface for printing messages
 - [ ] dump deployments for use with `kubectl apply -f`
-- [ ] add support multi-document `deployment.yml` so other objects can be added (e.g. acompanying services)
+- [x] support multi-document `deployment.yml` so other objects can be added (e.g. acompanying services)
 
 
 ## Whishlist


### PR DESCRIPTION
…YAML files

I will make the service deployment at least two PRs. This one adds support for multi document yaml files and some error handling.