### PR TITLE
Handle pip versions after 9.0.3

### DIFF
--- a/twyla/kubedeploy/__init__.py
+++ b/twyla/kubedeploy/__init__.py
@@ -7,8 +7,14 @@ from typing import List
 
 import click
 import git
-import pip
 import yaml
+
+try:
+    # noinspection PyProtectedMember
+    from pip._internal import main as pip_main
+except ImportError:
+    # we are using pip 9.0.3 or earlier
+    from pip import main as pip_main
 
 from twyla.kubedeploy import docker_helpers
 from twyla.kubedeploy.kube import Kube
@@ -52,7 +58,7 @@ def download_requirements(force: bool=False):
     prompt('Downloading requirements.')
     with open('requirements.txt') as f:
         deps = [line for line in f if line.startswith('git+ssh')]
-    pip.main(['download', '-q', '--dest', tmp, *deps])
+    pip_main(['download', '-q', '--dest', tmp, *deps])
     shutil.move(tmp, dest)
 
 

--- a/twyla/kubedeploy/test/test_commands.py
+++ b/twyla/kubedeploy/test/test_commands.py
@@ -303,7 +303,7 @@ key3:
 
     @mock.patch('twyla.kubedeploy.docker_helpers.open',
                 new=mock.mock_open(read_data=REQUIREMENTS))
-    @mock.patch('twyla.kubedeploy.pip')
+    @mock.patch('twyla.kubedeploy.pip_main')
     @mock.patch('twyla.kubedeploy.os')
     @mock.patch('twyla.kubedeploy.prompt')
     @mock.patch('twyla.kubedeploy.tempfile')
@@ -323,7 +323,7 @@ key3:
 
     @mock.patch('twyla.kubedeploy.docker_helpers.open',
                 new=mock.mock_open(read_data=REQUIREMENTS))
-    @mock.patch('twyla.kubedeploy.pip')
+    @mock.patch('twyla.kubedeploy.pip_main')
     @mock.patch('twyla.kubedeploy.os')
     @mock.patch('twyla.kubedeploy.prompt')
     @mock.patch('twyla.kubedeploy.tempfile')
@@ -333,7 +333,7 @@ key3:
                                                 mock_tempfile,
                                                 mock_prompt,
                                                 mock_os,
-                                                mock_pip):
+                                                mock_pip_main):
         mock_os.path.isfile.return_value = True
         mock_os.path.isdir.return_value = True
         mock_os.path.join.return_value = 'some/joined/path'
@@ -349,7 +349,7 @@ key3:
 
     @mock.patch('twyla.kubedeploy.docker_helpers.open',
                 new=mock.mock_open(read_data=REQUIREMENTS))
-    @mock.patch('twyla.kubedeploy.pip')
+    @mock.patch('twyla.kubedeploy.pip_main')
     @mock.patch('twyla.kubedeploy.os')
     @mock.patch('twyla.kubedeploy.prompt')
     @mock.patch('twyla.kubedeploy.tempfile')
@@ -359,7 +359,7 @@ key3:
                                    mock_tempfile,
                                    mock_prompt,
                                    mock_os,
-                                   mock_pip):
+                                   mock_pip_main):
         mock_os.path.isfile.return_value = True
         mock_os.path.isdir.return_value = False
         mock_os.path.join.return_value = 'some/joined/path'
@@ -368,7 +368,7 @@ key3:
 
         mock_tempfile.mkdtemp.assert_called_once_with()
         mock_prompt.assert_called_once_with('Downloading requirements.')
-        mock_pip.main.assert_called_once_with(
+        mock_pip_main.assert_called_once_with(
             ['download', '-q', '--dest', mock_tempfile.mkdtemp.return_value])
         mock_shutil.move.assert_called_once_with(
             mock_tempfile.mkdtemp.return_value,
@@ -377,7 +377,7 @@ key3:
 
     @mock.patch('twyla.kubedeploy.docker_helpers.open',
                 new=mock.mock_open(read_data=REQUIREMENTS))
-    @mock.patch('twyla.kubedeploy.pip')
+    @mock.patch('twyla.kubedeploy.pip_main')
     @mock.patch('twyla.kubedeploy.os')
     @mock.patch('twyla.kubedeploy.prompt')
     @mock.patch('twyla.kubedeploy.tempfile')
@@ -387,7 +387,7 @@ key3:
                                          mock_tempfile,
                                          mock_prompt,
                                          mock_os,
-                                         mock_pip):
+                                         mock_pip_main):
         mock_os.path.isfile.return_value = True
         mock_os.path.isdir.return_value = True
         mock_os.path.join.return_value = 'some/joined/path'
@@ -402,7 +402,7 @@ key3:
             mock.call('Downloading requirements.'),
         ])
 
-        mock_pip.main.assert_called_once_with(
+        mock_pip_main.assert_called_once_with(
             ['download', '-q', '--dest', mock_tempfile.mkdtemp.return_value])
         mock_shutil.move.assert_called_once_with(
             mock_tempfile.mkdtemp.return_value,


### PR DESCRIPTION
When downloading requirements, pip command execution fails for pip
versions > 9.0.3. This change allows for requirements to be downloaded
for all current versions of pip.

Resolves: #19